### PR TITLE
Use long tags in PHP

### DIFF
--- a/app/View/Problems/view.ctp
+++ b/app/View/Problems/view.ctp
@@ -34,7 +34,7 @@ if($contest_id) {
 <?php endfor; ?>
 </div>
 <div class="submit-button">
-<?
+<?php
 	echo $this->Html->link('Submit', '/submissions/submit/'.$problem['Problem']['id'].'/'.$contest_id, array('class' => 'btn btn-primary btn-large'));
 	echo $this->Html->link('Question', '/questions/index/'.$problem['Problem']['id'].'/'.$contest_id, array('class' => 'btn btn-large'));
 	echo $this->Html->link('Submissions', 'submission/'.$problem['Problem']['id'].'/'.$contest_id, array('class' => 'btn btn-large'));


### PR DESCRIPTION
PHP short tags doesn't work well with the interpreter shipped with Ubuntu 14.04 LTS.
This causes that Apache prints PHP codes on the "Problems" pages.
